### PR TITLE
more accurate representation about bft fault number and quorum

### DIFF
--- a/BEP126.md
+++ b/BEP126.md
@@ -40,7 +40,7 @@ finality feature is very useful, users can make sure they get the accurate infor
 then they can decide what to do next instantly.
 
 Currently, on BNB Smart chain, all the full nodes and validators need to wait until enough blocks have been produced
-to ensure a probabilistic finality. For BSC, with 21 validators, full nodes and validators can wait 2/3*21+1=15 blocks
+to ensure a probabilistic finality. For BSC, with 21 validators, full nodes and validators can wait 2/3*21=14 blocks
 to ensure a relatively secure finality, it would be quite long time for some critical applications.
 
 ## 5. Specification
@@ -107,7 +107,7 @@ The new longest chain rule can be described as follows.
 In the current Parlia consensus, the validator liveness is ½*v+1=11, which means when there are more than 11 validators
 online, the chain can get increased continuously.
 
-In this design, we should change the liveness from ½*v+1=11 to ⅔*v+1=15, this can protect the chain from getting increased
+In this design, we should change the liveness from ½*v+1=11 to ⅔*v=14, this can protect the chain from getting increased
 in a malicious fork.
 
 ### 5.2 Theory Proof
@@ -115,7 +115,7 @@ Assume the malicious validators are less than ⅓*v, honest validators are more 
 under the above rules, the vote can be propagated to all validators within one block time, then we can prove this fast
 finality mechanism has accountable safety and plausible liveness.
 
-Accountable safety means that two blocks in different forks cannot both be finalized unless more than ⅓*v validators
+Accountable safety means that two blocks in different forks cannot both be finalized unless ⅓*v or more validators
 violate the voting rules.
 
 Plausible liveness means that, regardless of any previous events, if ⅔*v+ validators follow the mechanism, then it’s
@@ -137,7 +137,7 @@ With these four properties in hand, we move to the main theorems.
 **Theorem 1 (Accountable Safety).** Two blocks in different forks cannot both be finalized.
 
 Let Am (with vote justified Am+1, meaning h(Am) + 1 == h(Am+1)) and Bn (with vote justified direct child Bn+1, meaning
-h(Bn) + 1 == h(Bn+1)) be distinct finalized blocks as following figure. Now suppose Am and Bn are on different forks,
+h(Bn) + 1 == h(Bn+1)) be distinct finalized blocks. Now suppose Am and Bn are on different forks,
 and without loss of generality h(Am) < h(Bn) (If h(Am) == h(Bn) it is clear that at least one honest validator violated
 Rule 1).
 
@@ -159,7 +159,7 @@ vote justified blocks, and once one of its direct child block has been vote just
 violating any vote rules.
 
 ### 5.3 Reward
-In order to make the block get finalized faster, once the validators see the votes for the block are more than 2/3 validators,
+In order to make the block get finalized faster, once the validators see the votes for the block are 2/3 or more validators,
 these votes will be wrapped and the reward will be distributed to these wrapped voted validators, the remained validators
 who didn’t vote for the block or vote later won’t get reward.
 


### PR DESCRIPTION
Rational:
in BFT consensus, when v = 3f+1, system can tolerate  f  evil validators, and quorum is 2f+1
but when n%3 != 1，
f  should be less than 1/3v, meaning 1/3v is **not included** even when it's a integer
    so **1/3v or more** evil validators can destroy the system
q  should be more than 2/3v and 2/3v is **included** when it's a integer, 
     so we can express q as “2/3v or more” for more accuration

when v = 21, quorum is 2/3v =14, we use it to replace 15

